### PR TITLE
Make quickload of a non-existent slot a no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 # v4.10.0
 - You can now call `:setClickHandler()` directly on the button object from Lua instead of having to use `Gui.setClickHandler()`.
+- Attempting to `quickLoad` a save slot which doesn't exist now logs a warning instead of throwing an exception.
 - fix: Initial window size limits are now properly applied when the window is (almost) larger than the screen.
 - fix: The default choice screen displays previously selected choices in a different color. If you saved at a choice, the colors wouldn't update when loading.
 

--- a/core/src/main/lua/builtin/script/vn/save.lua
+++ b/core/src/main/lua/builtin/script/vn/save.lua
@@ -29,12 +29,19 @@ end
 -- @param[opt=nil] userdata table
 -- @param[opt=nil] screenshot table (screenshot, width, height)
 function quickSave(slot, userdata, screenshot)
-    return Save.save(Save.getQuickSaveSlot(slot), userdata, screenshot)
+    slot = Save.getQuickSaveSlot(slot or 1)
+    return Save.save(slot, userdata, screenshot)
 end
 
 ---Loads the quick-save slot with the given number (1..99)
+-- If no save file exists with that number, this function does nothing
 function quickLoad(slot)
-    return Save.load(Save.getQuickSaveSlot(slot))
+    slot = Save.getQuickSaveSlot(slot or 1)
+    if not Save.getSaveExists(slot) then
+        Log.warn("Nothing to quickLoad, save {} doesn't exist", slot)
+        return
+    end
+    return Save.load(slot)
 end
 
 ---Autosave

--- a/core/src/test/lua/script/integration/save/quicksaveload.lvn
+++ b/core/src/test/lua/script/integration/save/quicksaveload.lvn
@@ -1,5 +1,9 @@
 @@
 
+--quickLoad a slot that doesn't exist (a no-op)
+luaAssert(not Save.getSaveExists(42))
+quickLoad(42)
+
 x = 1
 quickSave(5)
 


### PR DESCRIPTION
The previous behavior was to crash which is a bit extreme for an
otherwise harmless mistake.